### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pipenv run python run.py"

--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ pipenv run pytest --cov=robot -b
 ``` text
 pipenv run python run.py
 ```
+[![Run on Repl.it](https://repl.it/badge/github/dhruvinsh/mars_rover)](https://repl.it/github/dhruvinsh/mars_rover)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).